### PR TITLE
Avoid newlines in setuptools description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     version='2.1.0.dev0',
     author="Zope Project",
     author_email="zope-dev@zope.org",
-    description=read('README.rst'),
+    description=read('README.rst').splitlines()[0],
     long_description='\n\n'.join([
         read('src', 'zc', 'queue', 'queue.rst'),
         read('CHANGES.rst'),


### PR DESCRIPTION
Fixes

    /usr/lib/python3/dist-packages/setuptools/dist.py:125: UserWarning: newlines not allowed and will break in the future
      warnings.warn("newlines not allowed and will break in the future")

printed by `python setup.py sdist` and friends.

Closes #5.